### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # stock-tracker-turing
-tock tracker sample app for grad program #5037
+Stock tracker sample app for grad program #5037


### PR DESCRIPTION
Change typo in README from "tock" to "Stock".